### PR TITLE
Detect ARM64 with MSVC

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -60,6 +60,7 @@ and agreed to irrevocably license their contributions under the Duktape
 * TheBrokenRail (https://github.com/TheBrokenRail)
 * Jesse Doyle (https://github.com/jessedoyle)
 * Gero Kuehn (https://github.com/dc6jgk)
+* James Swift (https://github.com/phraemer)
 
 Other contributions
 ===================

--- a/config/helper-snippets/DUK_F_ARM.h.in
+++ b/config/helper-snippets/DUK_F_ARM.h.in
@@ -1,7 +1,7 @@
 /* ARM */
-#if defined(__arm__) || defined(__thumb__) || defined(_ARM) || defined(_M_ARM) || defined(__aarch64__)
+#if defined(__arm__) || defined(__thumb__) || defined(_ARM) || defined(_M_ARM) || defined(_M_ARM64) || defined(__aarch64__)
 #define DUK_F_ARM
-#if defined(__LP64__) || defined(_LP64) || defined(__arm64) || defined(__arm64__) || defined(__aarch64__)
+#if defined(__LP64__) || defined(_LP64) || defined(__arm64) || defined(__arm64__) || defined(_M_ARM64) || defined(__aarch64__)
 #define DUK_F_ARM64
 #else
 #define DUK_F_ARM32


### PR DESCRIPTION
For compiling for ARM64 with MSVC we need to check for these defines.